### PR TITLE
build: add make install/uninstall targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,13 @@
+# Installation directories following GNU conventions
+prefix = /usr/local
+exec_prefix = $(prefix)
+bindir = $(exec_prefix)/bin
+sbindir = $(exec_prefix)/sbin
+datarootdir = $(prefix)/share
+datadir = $(datarootdir)
+includedir = $(prefix)/include
+mandir = $(datarootdir)/man
+
 BIN=bin
 OBJ=obj
 SRC=src
@@ -8,7 +18,10 @@ LDLIBS = -lncurses
 NCURSES_H = /usr/include/ncurses.h
 UNAME = $(shell uname)
 
-all: nms sneakers
+.PHONY: all install uninstall clean
+
+EXES = nms sneakers
+all: $(EXES)
 
 nms: $(OBJ)/nms.o $(OBJ)/main.o | $(BIN)
 	$(CC) $(CFLAGS) -o $(BIN)/$@ $^ $(LDLIBS)
@@ -42,3 +55,11 @@ endif
 clean:
 	rm -rf $(BIN)
 	rm -rf $(OBJ)
+
+install:
+	install -d $(bindir)
+	cd $(BIN) && install $(EXES) $(DESTDIR)$(bindir)
+
+uninstall:
+	for exe in $(EXES); do rm $(DESTDIR)$(bindir)/$$exe; done
+


### PR DESCRIPTION
Adds `make install` and `make uninstall` targets, with support for `prefix` and `DESTDIR`. Follows the [GNU Makefile Conventions](https://www.gnu.org/prep/standards/html_node/Directory-Variables.html#Directory-Variables) for directory variables.

Closes #11 (which added `install` but lacked `prefix` support)