### PR TITLE
Added the `-f` flag to change the foreground color

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,6 +134,7 @@ typedef struct {
     int input_cursor_y;
     bool show_cursor;
     bool auto_decrypt;
+    int foreground_color;
 } NmsArgs;
 ```
 * `char *src`
@@ -149,6 +150,8 @@ Useful for displaying menus:
   * Set to `true` if you want the cursor to be visible during the text decryption effect. It is set to `false` by default.
 * `bool auto_decrypt`
   * Set to `true` to automatically start the decryption effect, eliminating the need for the user to press a key to start it.
+ * `int foreground_color`
+   * Use this to assign a default (ncurses) color to the foreground
 
 Assign values to the structure members as needed. Then simply pass a pointer to the structure to the
 nms_exec() function:

--- a/README.md
+++ b/README.md
@@ -70,6 +70,11 @@ eliminating the need for the user to press a key to start it.
 ls -l / | nms -a
 ```
 
+Use the `-f` option to set foreground color to either white, yellow, black, magenta, blue, green, or red - this is blue by default.
+```
+ls -l / | nms -f green
+```
+
 Using the Module in Your Program
 ---------------------------------
 

--- a/src/main.c
+++ b/src/main.c
@@ -12,8 +12,11 @@ int main(int argc, char *argv[]) {
 	NmsArgs args = INIT_NMSARGS;
 
 	// Processing command arguments
-	while ((o = getopt(argc, argv, "av")) != -1) {
+	while ((o = getopt(argc, argv, "f:av")) != -1) {
 		switch (o) {
+			case 'f':
+                args.foreground_color = getColorByName(optarg, args.foreground_color);
+                break;
 			case 'a':
                 args.auto_decrypt = true;
                 break;

--- a/src/nms.c
+++ b/src/nms.c
@@ -86,7 +86,7 @@ char nms_exec(NmsArgs *args) {
 	// Setting up and starting colors if terminal supports them
 	if (has_colors()) {
 		start_color();
-		init_pair(1, COLOR_BLUE, COLOR_BLACK);
+		init_pair(1, args->foreground_color, COLOR_BLACK);
 	}
 
 	// Get terminal window size
@@ -283,4 +283,44 @@ char getMaskChar(void) {
 	                  "!@#$%^&*()-_=+{}[]:;|\\\"'<>,.?/";
 
 	return maskChars[rand() % strlen(maskChars)];
+}
+
+/*
+ * char getColorByName(char *string, int fallback)
+ *
+ * DESCR:
+ * Returns an ncurses color by its name.
+ *
+ */
+int getColorByName(char *string, int fallback) {
+
+	if(strcmp("white", string) == 0) {
+		return COLOR_WHITE;
+	}
+
+	if(strcmp("yellow", string) == 0) {
+		return COLOR_YELLOW;
+	}
+
+	if(strcmp("black", string) == 0) {
+		return COLOR_BLACK;
+	}
+
+	if(strcmp("magenta", string) == 0) {
+		return COLOR_MAGENTA;
+	}
+
+	if(strcmp("blue", string) == 0) {
+		return COLOR_BLUE;
+	}
+
+	if(strcmp("green", string) == 0) {
+		return COLOR_GREEN;
+	}
+
+	if(strcmp("red", string) == 0) {
+		return COLOR_RED;
+	}
+
+	return fallback;
 }

--- a/src/nms.h
+++ b/src/nms.h
@@ -3,9 +3,10 @@
 
 #include <stddef.h>
 #include <stdbool.h>
+#include <ncurses.h>
 
 // Default arguments for nms_exec()
-#define INIT_NMSARGS { NULL, NULL, -1, -1, false, false }
+#define INIT_NMSARGS { NULL, NULL, -1, -1, false, false , COLOR_BLUE }
 
 // Argument structure for nms_exec()
 typedef struct {
@@ -15,9 +16,12 @@ typedef struct {
 	int input_cursor_y;
 	bool show_cursor;
 	bool auto_decrypt;
+	int foreground_color;
 } NmsArgs;
 
 // Display the characters stored in the display queue
 char nms_exec(NmsArgs *);
+
+int  getColorByName(char *string, int fallback);
 
 #endif


### PR DESCRIPTION
I've added the `-f` flag enabling the selection of the following colors:-

- white
- yellow
- black
- magenta
- blue
- green
- red

By default the foreground is blue, as per the current implementation. I did at the `-b` for background color selection but it looked a bit odd so dropped it.

This is not a language I know, so please go easy on me. I am however, looking forward to your feedback. 😄 