### PR TITLE
Makefile: Add DESTDIR to make packaging easier

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,11 +1,11 @@
 # Installation directories following GNU conventions
 prefix = /usr/local
-exec_prefix = $(prefix)
+exec_prefix = $(DESTDIR)$(prefix)
 bindir = $(exec_prefix)/bin
 sbindir = $(exec_prefix)/sbin
-datarootdir = $(prefix)/share
+datarootdir = $(DESTDIR)$(prefix)/share
 datadir = $(datarootdir)
-includedir = $(prefix)/include
+includedir = $(DESTDIR)$(prefix)/include
 mandir = $(datarootdir)/man
 
 BIN=bin


### PR DESCRIPTION
When packaging, DESTDIR will be set to a directory
with write permissions for non-root users.