### PR TITLE
Makefile: add DESTDIR support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -60,9 +60,9 @@ clean:
 	rm -rf $(OBJ)
 
 install:
-	install -d $(bindir)
-	cd $(BIN) && install $(EXES) $(bindir)
+	install -d $(DESTDIR)$(bindir)
+	cd $(BIN) && install $(EXES) $(DESTDIR)$(bindir)
 
 uninstall:
-	for exe in $(EXES); do rm $(bindir)/$$exe; done
+	for exe in $(EXES); do rm $(DESTDIR)$(bindir)/$$exe; done
 


### PR DESCRIPTION
Adds `DESTDIR` support back to the Makefile.

Note: the apparently uninitialized `$DESTDIR` variable is fine. It's supposed to be empty by default, and just supplied on the command line as an argument to `make` when used for packaging.

Closes #20.