### PR TITLE
added "docker" as an "operating system"

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,12 @@
+FROM alpine:3.4
+
+WORKDIR /app
+RUN apk add --no-cache gcc ncurses git make sudo ncurses-dev musl-dev; \
+    git clone https://github.com/bartobri/no-more-secrets.git; \
+    cd /app/no-more-secrets; \
+    make && make install && make clean; \
+    apk del gcc git make sudo ncurses-dev musl-dev
+
+CMD nms
+
+

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -82,6 +82,21 @@ Once Homebrew is installed, you can install no-more-secrets:
 brew install no-more-secrets
 ```
 
+#### Docker Container
+
+Run 
+
+```
+docker build -t bartobri/no-more-secrets .
+```
+to build the container.
+
+Run with
+```
+ls -l | docker run --rm -i -e TERM=$TERM bartobri/no-more-secrets 
+```
+
+
 #### Generic Instructions
 
 First, make sure you have the ncurses header installed:


### PR DESCRIPTION
Thought, its a nice idea to have it as a docker container.
Could also be added to hub.docker.com for automated builds.

Image size: 8.35MB.

I tested it on my mac with various terminal programs. Not all terminal settings produced satisfying results. Hope its fine for a first version.