### PR TITLE
Add support for MinGW on Windows

### DIFF
--- a/src/nmstermio.c
+++ b/src/nmstermio.c
@@ -17,6 +17,9 @@
 #include <termios.h>
 #include <unistd.h>
 #include <sys/ioctl.h>
+#ifndef FIONREAD
+#include <sys/socket.h>
+#endif
 
 // Macros for VT100 codes
 #define CLEAR_SCR()          printf("\033[2J")           // Clear Screen


### PR DESCRIPTION
The only error I get when building `nms` under MinGW is `FIONREAD undeclared`. It turns out that `FIONREAD` is defined in `sys/socket.h` instead of `sys/ioctl.h`. `#include <sys/socket.h>` fixes the problem.

The compiled binary (without ncurses) works perfectly on ConEmu.
![ezgif-2-fb17e01c0a](https://cloud.githubusercontent.com/assets/9519031/24079361/415004b8-0cc1-11e7-8a18-a7545b4b4311.gif)
