### PR TITLE
Fix buffer overflow when querying cursor row.

### DIFF
--- a/src/nmstermio.c
+++ b/src/nmstermio.c
@@ -260,11 +260,11 @@ int nmstermio_get_cursor_row(void) {
 	int i, r = 0;
 	int row = 0;
 	char buf[10];
-	char *cmd = "\033[6n";
+	char cmd[] = "\033[6n";
 
 	memset(buf, 0, sizeof(buf));
 
-	write(STDOUT_FILENO, cmd, sizeof(cmd));
+	write(STDOUT_FILENO, cmd, sizeof(cmd) - 1);
 
 	r = read(STDIN_FILENO, buf, sizeof(buf));
 


### PR DESCRIPTION
`sizeof(cmd) == sizeof(char*) == 8` (on 64-bit), but the string is only 4 characters + NUL.

Fixes #60.