### PR TITLE
Add online live demo to README.md.

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,11 @@ $ make sneakers-ncurses     ## Optional
 $ sudo make install
 ```
 
+#### Live Demo:
+
+You can also play with `nms` in a free online workspace:
+[Try `nms` in Gitpod](https://gitpod.io#https://github.com/bartobri/no-more-secrets).
+
 Usage
 -----
 


### PR DESCRIPTION
Hi @bartobri, thanks a lot for making `nms`! It is really fun to use.

I work on Gitpod, a service that provides free online workspaces, and I just had to try `nms` in it -- and it seems to work pretty well! Here is a demo:

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io#https://github.com/bartobri/no-more-secrets)
<img width="1552" alt="screenshot 2019-02-11 at 11 01 23" src="https://user-images.githubusercontent.com/599268/52556320-86496700-2dec-11e9-9a47-53045e69ad15.png">
The only thing is that apparently you need to hit `Enter` for the animation to begin. Is that expected? If so, maybe it could be worth printing something like `Press 'Enter' to decrypt` just below the obfuscated text in the live demo.

(FYI, here is the [configuration](https://github.com/gitpod-io/definitely-gp/blob/master/no-more-secrets/.gitpod.yml) I wrote to make `nms` run automatically in Gitpod.)
