### PR TITLE
Fixed bug where piping into sneakers caused memory corruption

### DIFF
--- a/src/sneakers.c
+++ b/src/sneakers.c
@@ -32,7 +32,11 @@ int main(void) {
 
 	// Get terminal dimentions (needed for centering)
 	struct winsize w;
-	ioctl(0, TIOCGWINSZ, &w);
+    // if not an interactive tty, w is not populated, resulting in UB
+	if (ioctl(0, TIOCGWINSZ, &w) == -1) {
+        perror("Input not from an interactive terminal");
+        return 1;
+    }
 	termCols = w.ws_col;
 
 	// Allocate space for our display string
@@ -45,6 +49,7 @@ int main(void) {
 	// Allocate space for our display string
 	if ((display_uc = malloc(20 * termCols)) == NULL)
 	{
+        free(display);
 		fprintf(stderr, "Memory Allocation Error. Quitting!\n");
 		return 1;
 	}


### PR DESCRIPTION
Previously if input was piped into sneakers - such as `echo "" | sneakers`, it would cause a crash as term_cols depended on uninitialised memory (as ioctl failed), resulting in a failed free at the end.

In addition to this, I added a missing free call to the failure of the second malloc.

