### PR TITLE
Add an argument to adjust the speed of decryption

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,7 @@ $ ls -l | nms
 $ ls -l | nms -a           // Set auto-decrypt flag
 $ ls -l | nms -s           // Set flag to mask space characters
 $ ls -l | nms -f green     // Set foreground color to green
+$ ls -l | nms -t 1000      // Set the decryption speed to 1000 (half of default)
 $ ls -l | nms -c           // Clear screen
 $ nms -v                   // Display version
 ```

--- a/README.md
+++ b/README.md
@@ -118,6 +118,10 @@ Set the foreground color of the decrypted text to the color
 specified. Valid options are white, yellow, black, magenta, blue, green,
 or red. This is blue by default.
 
+`-t <time>`
+
+Set the speed of the decryption. Adjusts both the jumbling and reveal stages of the animation. Default is 2000.
+
 `-c`
 
 Clear the screen prior to printing any output. Specifically,

--- a/nms.6
+++ b/nms.6
@@ -23,6 +23,10 @@ display version info
 .BI -f <COLOR>
 set the foreground color of the decrypted text to the color specified.
 Valid options are white, black, yellow, magenta, cyan, blue (default), green, or red.
+.TP
+.BI -t <TIME>
+set the speed of the decryption.
+Default is 2000.
 .SH DESCRIPTION
 This command works on piped data. Pipe any ASCII or UTF-8 text to nms,
 and it will apply the hollywood effect, seen on screen in the 1992 hacker movie Sneakers.

--- a/src/nms.c
+++ b/src/nms.c
@@ -22,12 +22,15 @@ int main(int argc, char *argv[])
 
 	input = NULL;
 
-	while ((o = getopt(argc, argv, "f:ascv")) != -1)
+	while ((o = getopt(argc, argv, "f:t:ascv")) != -1)
 	{
 		switch (o)
 		{
 			case 'f':
 				nmseffect_set_foregroundcolor(optarg);
+				break;
+			case 't':
+				nmseffect_set_jumbletime(optarg);
 				break;
 			case 'a':
 				nmseffect_set_autodecrypt(1);

--- a/src/nmseffect.h
+++ b/src/nmseffect.h
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2017 Brian Barto
- * 
+ *
  * This program is free software; you can redistribute it and/or modify it
  * under the terms of the GPL License. See LICENSE for more details.
  */
@@ -11,6 +11,7 @@
 // Function prototypes
 char nmseffect_exec(unsigned char *, int string_len);
 void nmseffect_set_foregroundcolor(char *);
+void nmseffect_set_jumbletime(char *);
 void nmseffect_set_returnopts(char *);
 void nmseffect_set_autodecrypt(int);
 void nmseffect_set_maskblank(int);


### PR DESCRIPTION
Add an argument to adjust the speed of decryption. Value adjusts the jumble time as well as the reveal loop speed. The 'Decrement reveal time' step was broken out into a separate value since things looked better overall if that remained fixed while the time was changed.

(Sorry about the messy diff, looks like my editor nuked out some extra whitespace.)