### PR TITLE
Windows support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ obj/*
 .vs
 notes.txt
 /.zig-cache
+/zig-out

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ bin/*
 obj/*
 .vs
 notes.txt
+/.zig-cache

--- a/Makefile
+++ b/Makefile
@@ -15,23 +15,40 @@ SRC=src
 CC ?= gcc
 CFLAGS ?= -Wextra -Wall -O2
 
-.PHONY: all install uninstall clean
+ifeq ($(OS),Windows_NT)
+	EXEEXT=.exe
+	TERMIO_SRC=nmstermio_win
+	PLATFORM_LIBS=-lkernel32 -luser32
+else
+	EXEEXT=
+	TERMIO_SRC=nmstermio
+	PLATFORM_LIBS=
+endif
 
-nms: $(OBJ)/input.o $(OBJ)/error.o $(OBJ)/nmscharset.o $(OBJ)/nmstermio.o $(OBJ)/nmseffect.o $(OBJ)/nms.o | $(BIN)
-	$(CC) $(CFLAGS) -o $(BIN)/$@ $^
+NMS_EXE=$(BIN)/nms$(EXEEXT)
+SNEAKERS_EXE=$(BIN)/sneakers$(EXEEXT)
 
-sneakers: $(OBJ)/nmscharset.o $(OBJ)/nmstermio.o $(OBJ)/nmseffect.o $(OBJ)/sneakers.o | $(BIN)
-	$(CC) $(CFLAGS) -o $(BIN)/$@ $^
+.PHONY: all install uninstall clean nms sneakers all-ncurses nms-ncurses sneakers-ncurses
 
 all: nms sneakers
 
+nms: $(NMS_EXE)
+
+sneakers: $(SNEAKERS_EXE)
+
 all-ncurses: nms-ncurses sneakers-ncurses
 
+$(NMS_EXE): $(OBJ)/input.o $(OBJ)/error.o $(OBJ)/nmscharset.o $(OBJ)/$(TERMIO_SRC).o $(OBJ)/nmseffect.o $(OBJ)/nms.o | $(BIN)
+	$(CC) $(CFLAGS) -o $@ $^ $(PLATFORM_LIBS)
+
+$(SNEAKERS_EXE): $(OBJ)/nmscharset.o $(OBJ)/$(TERMIO_SRC).o $(OBJ)/nmseffect.o $(OBJ)/sneakers.o | $(BIN)
+	$(CC) $(CFLAGS) -o $@ $^ $(PLATFORM_LIBS)
+
 nms-ncurses: $(OBJ)/input.o $(OBJ)/error.o $(OBJ)/nmscharset.o $(OBJ)/nmstermio_ncurses.o $(OBJ)/nmseffect.o $(OBJ)/nms.o | $(BIN)
-	$(CC) $(CFLAGS) -o $(BIN)/nms $^ -lncursesw
+	$(CC) $(CFLAGS) -o $(NMS_EXE) $^ -lncursesw
 
 sneakers-ncurses: $(OBJ)/nmscharset.o $(OBJ)/nmstermio_ncurses.o $(OBJ)/nmseffect.o $(OBJ)/sneakers.o | $(BIN)
-	$(CC) $(CFLAGS) -o $(BIN)/sneakers $^ -lncursesw
+	$(CC) $(CFLAGS) -o $(SNEAKERS_EXE) $^ -lncursesw
 
 $(OBJ)/%.o: $(SRC)/%.c | $(OBJ)
 	$(CC) $(CFLAGS) -o $@ -c $<

--- a/README.md
+++ b/README.md
@@ -60,6 +60,23 @@ $ make sneakers             ## Optional
 $ sudo make install
 ```
 
+#### Build with Zig (cross-platform alternative)
+
+If you have [Zig](https://ziglang.org/) 0.15.1 or newer installed, you can use
+the provided `build.zig` script instead of `make`. This approach is handy on
+Windows because it uses Zig's bundled C toolchain and the native Windows
+terminal backend.
+
+```
+$ git clone https://github.com/bartobri/no-more-secrets.git
+$ cd ./no-more-secrets
+$ zig build                 # builds nms and sneakers into zig-out/bin
+$ zig build run-nms -- -v   # optional helpers for quick testing
+```
+
+The resulting executables are placed in `zig-out/bin`. You can copy them to a
+preferred location or prepend that directory to your `PATH`.
+
 #### Uninstall:
 
 ```

--- a/build.zig
+++ b/build.zig
@@ -1,0 +1,90 @@
+const std = @import("std");
+
+pub fn build(b: *std.Build) void {
+    const target = b.standardTargetOptions(.{});
+    const optimize = b.standardOptimizeOption(.{});
+    const common_cflags = &[_][]const u8{ "-std=c99", "-Wall", "-Wextra" };
+
+    const nms_module = b.createModule(.{
+        .target = target,
+        .optimize = optimize,
+    });
+    const sneakers_module = b.createModule(.{
+        .target = target,
+        .optimize = optimize,
+    });
+
+    const nms = b.addExecutable(.{
+        .name = "nms",
+        .root_module = nms_module,
+    });
+    nms.linkLibC();
+    nms.addCSourceFiles(.{
+        .files = &.{
+            "src/error.c",
+            "src/input.c",
+            "src/nmscharset.c",
+            "src/nmseffect.c",
+            "src/nms.c",
+        },
+        .flags = common_cflags,
+    });
+
+    const sneakers = b.addExecutable(.{
+        .name = "sneakers",
+        .root_module = sneakers_module,
+    });
+    sneakers.linkLibC();
+    sneakers.addCSourceFiles(.{
+        .files = &.{
+            "src/error.c",
+            "src/nmscharset.c",
+            "src/nmseffect.c",
+            "src/sneakers.c",
+        },
+        .flags = common_cflags,
+    });
+
+    if (target.result.os.tag == .windows) {
+        nms.addCSourceFiles(.{
+            .files = &.{"src/nmstermio_win.c"},
+            .flags = common_cflags,
+        });
+        sneakers.addCSourceFiles(.{
+            .files = &.{"src/nmstermio_win.c"},
+            .flags = common_cflags,
+        });
+        nms.linkSystemLibrary("kernel32");
+        nms.linkSystemLibrary("user32");
+        sneakers.linkSystemLibrary("kernel32");
+        sneakers.linkSystemLibrary("user32");
+    } else {
+        nms.addCSourceFiles(.{
+            .files = &.{"src/nmstermio.c"},
+            .flags = common_cflags,
+        });
+        sneakers.addCSourceFiles(.{
+            .files = &.{"src/nmstermio.c"},
+            .flags = common_cflags,
+        });
+    }
+
+    b.installArtifact(nms);
+    b.installArtifact(sneakers);
+
+    const run_nms_cmd = b.addRunArtifact(nms);
+    const run_sneakers_cmd = b.addRunArtifact(sneakers);
+
+    if (b.args) |args| {
+        run_nms_cmd.addArgs(args);
+        run_sneakers_cmd.addArgs(args);
+    }
+
+    run_nms_cmd.step.dependOn(b.getInstallStep());
+    const run_nms_step = b.step("run-nms", "Build and run nms");
+    run_nms_step.dependOn(&run_nms_cmd.step);
+
+    run_sneakers_cmd.step.dependOn(b.getInstallStep());
+    const run_sneakers_step = b.step("run-sneakers", "Build and run sneakers");
+    run_sneakers_step.dependOn(&run_sneakers_cmd.step);
+}

--- a/src/nmstermio_win.c
+++ b/src/nmstermio_win.c
@@ -1,0 +1,353 @@
+/*
+ * Windows-specific terminal IO implementation.
+ */
+
+#ifdef _WIN32
+#define WIN32_LEAN_AND_MEAN
+
+#include <windows.h>
+#include <conio.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "nmstermio.h"
+
+#define FG_MASK (FOREGROUND_RED | FOREGROUND_GREEN | FOREGROUND_BLUE | FOREGROUND_INTENSITY)
+#define BG_MASK (BACKGROUND_RED | BACKGROUND_GREEN | BACKGROUND_BLUE | BACKGROUND_INTENSITY)
+
+static HANDLE hIn = INVALID_HANDLE_VALUE;
+static HANDLE hOut = INVALID_HANDLE_VALUE;
+static DWORD originalInMode = 0;
+static DWORD originalOutMode = 0;
+static int modesSaved = 0;
+static int clearScr = 0;
+static int foregroundColor = 4; /* COLOR_BLUE */
+static WORD defaultAttributes = FG_MASK;
+static CONSOLE_CURSOR_INFO savedCursorInfo;
+static int cursorHidden = 0;
+
+static void ensure_handles(void);
+static void clear_console(void);
+static void write_utf8(const char *s);
+static WORD map_color(int color);
+
+static void ensure_handles(void)
+{
+	if (hIn == INVALID_HANDLE_VALUE)
+	{
+		hIn = GetStdHandle(STD_INPUT_HANDLE);
+	}
+	if (hOut == INVALID_HANDLE_VALUE)
+	{
+		hOut = GetStdHandle(STD_OUTPUT_HANDLE);
+	}
+}
+
+static void clear_console(void)
+{
+	CONSOLE_SCREEN_BUFFER_INFO info;
+	DWORD written;
+	COORD origin = {0, 0};
+
+	if (!GetConsoleScreenBufferInfo(hOut, &info))
+	{
+		return;
+	}
+
+	FillConsoleOutputCharacterW(hOut, L' ', info.dwSize.X * info.dwSize.Y, origin, &written);
+	FillConsoleOutputAttribute(hOut, defaultAttributes, info.dwSize.X * info.dwSize.Y, origin, &written);
+	SetConsoleCursorPosition(hOut, origin);
+}
+
+static void write_utf8(const char *s)
+{
+	if (s == NULL)
+	{
+		return;
+	}
+
+	size_t len = strlen(s);
+	if (len == 0)
+	{
+		return;
+	}
+
+	int wlen = MultiByteToWideChar(CP_UTF8, 0, s, (int)len, NULL, 0);
+	if (wlen <= 0)
+	{
+		DWORD written = 0;
+		WriteConsoleA(hOut, s, (DWORD)len, &written, NULL);
+		return;
+	}
+
+	wchar_t *wbuf = (wchar_t *)malloc((size_t)(wlen + 1) * sizeof(wchar_t));
+	if (wbuf == NULL)
+	{
+		DWORD written = 0;
+		WriteConsoleA(hOut, s, (DWORD)len, &written, NULL);
+		return;
+	}
+
+	MultiByteToWideChar(CP_UTF8, 0, s, (int)len, wbuf, wlen);
+	DWORD written = 0;
+	WriteConsoleW(hOut, wbuf, (DWORD)wlen, &written, NULL);
+	free(wbuf);
+}
+
+static WORD map_color(int color)
+{
+	switch (color)
+	{
+		case 0: /* COLOR_BLACK */
+			return 0;
+		case 1: /* COLOR_RED */
+			return FOREGROUND_RED | FOREGROUND_INTENSITY;
+		case 2: /* COLOR_GREEN */
+			return FOREGROUND_GREEN | FOREGROUND_INTENSITY;
+		case 3: /* COLOR_YELLOW */
+			return FOREGROUND_RED | FOREGROUND_GREEN | FOREGROUND_INTENSITY;
+		case 4: /* COLOR_BLUE */
+			return FOREGROUND_BLUE | FOREGROUND_INTENSITY;
+		case 5: /* COLOR_MAGENTA */
+			return FOREGROUND_RED | FOREGROUND_BLUE | FOREGROUND_INTENSITY;
+		case 6: /* COLOR_CYAN */
+			return FOREGROUND_GREEN | FOREGROUND_BLUE | FOREGROUND_INTENSITY;
+		case 7: /* COLOR_WHITE */
+			return FOREGROUND_RED | FOREGROUND_GREEN | FOREGROUND_BLUE | FOREGROUND_INTENSITY;
+		default:
+			return FOREGROUND_BLUE | FOREGROUND_INTENSITY;
+	}
+}
+
+void nmstermio_init_terminal(void)
+{
+	ensure_handles();
+	if (hIn == INVALID_HANDLE_VALUE || hOut == INVALID_HANDLE_VALUE)
+	{
+		return;
+	}
+
+	if (!modesSaved)
+	{
+		GetConsoleMode(hIn, &originalInMode);
+		GetConsoleMode(hOut, &originalOutMode);
+
+		CONSOLE_SCREEN_BUFFER_INFO info;
+		if (GetConsoleScreenBufferInfo(hOut, &info))
+		{
+			defaultAttributes = info.wAttributes;
+		}
+		else
+		{
+			defaultAttributes = FOREGROUND_RED | FOREGROUND_GREEN | FOREGROUND_BLUE;
+		}
+
+		GetConsoleCursorInfo(hOut, &savedCursorInfo);
+		modesSaved = 1;
+	}
+
+	DWORD inputMode = originalInMode;
+	inputMode &= ~(ENABLE_ECHO_INPUT | ENABLE_LINE_INPUT);
+	inputMode |= ENABLE_EXTENDED_FLAGS;
+	SetConsoleMode(hIn, inputMode);
+
+	SetConsoleMode(hOut, originalOutMode | ENABLE_PROCESSED_OUTPUT);
+
+	if (clearScr)
+	{
+		clear_console();
+		CONSOLE_CURSOR_INFO cursor = savedCursorInfo;
+		cursor.bVisible = FALSE;
+		SetConsoleCursorInfo(hOut, &cursor);
+		cursorHidden = 1;
+	}
+	else
+	{
+		cursorHidden = 0;
+	}
+}
+
+void nmstermio_restore_terminal(void)
+{
+	ensure_handles();
+
+	if (modesSaved)
+	{
+		SetConsoleMode(hIn, originalInMode);
+		SetConsoleMode(hOut, originalOutMode);
+	}
+
+	if (cursorHidden)
+	{
+		SetConsoleCursorInfo(hOut, &savedCursorInfo);
+		cursorHidden = 0;
+	}
+}
+
+int nmstermio_get_rows(void)
+{
+	ensure_handles();
+	CONSOLE_SCREEN_BUFFER_INFO info;
+
+	if (!GetConsoleScreenBufferInfo(hOut, &info))
+	{
+		return 25;
+	}
+
+	return info.srWindow.Bottom - info.srWindow.Top + 1;
+}
+
+int nmstermio_get_cols(void)
+{
+	ensure_handles();
+	CONSOLE_SCREEN_BUFFER_INFO info;
+
+	if (!GetConsoleScreenBufferInfo(hOut, &info))
+	{
+		return 80;
+	}
+
+	return info.srWindow.Right - info.srWindow.Left + 1;
+}
+
+int nmstermio_get_cursor_row(void)
+{
+	ensure_handles();
+	CONSOLE_SCREEN_BUFFER_INFO info;
+
+	if (!GetConsoleScreenBufferInfo(hOut, &info))
+	{
+		return 0;
+	}
+
+	return (info.dwCursorPosition.Y - info.srWindow.Top) + 1;
+}
+
+void nmstermio_move_cursor(int y, int x)
+{
+	ensure_handles();
+	CONSOLE_SCREEN_BUFFER_INFO info;
+	COORD pos;
+
+	if (!GetConsoleScreenBufferInfo(hOut, &info))
+	{
+		return;
+	}
+
+	pos.X = (SHORT)x;
+	if (y <= 0)
+	{
+		pos.Y = info.srWindow.Top;
+	}
+	else
+	{
+		pos.Y = (SHORT)(info.srWindow.Top + y - 1);
+	}
+
+	SetConsoleCursorPosition(hOut, pos);
+}
+
+void nmstermio_print_string(char *s)
+{
+	ensure_handles();
+	write_utf8(s);
+}
+
+void nmstermio_refresh(void)
+{
+	fflush(stdout);
+}
+
+void nmstermio_clear_input(void)
+{
+	ensure_handles();
+
+	if (hIn != INVALID_HANDLE_VALUE)
+	{
+		FlushConsoleInputBuffer(hIn);
+	}
+
+	while (_kbhit())
+	{
+		_getch();
+	}
+}
+
+char nmstermio_get_char(void)
+{
+	int c = _getch();
+	return (char)c;
+}
+
+void nmstermio_print_reveal_string(char *s, int colorOn)
+{
+	ensure_handles();
+
+	WORD target = defaultAttributes;
+	if (colorOn)
+	{
+		target = (defaultAttributes & BG_MASK) | map_color(foregroundColor);
+	}
+
+	SetConsoleTextAttribute(hOut, target);
+	write_utf8(s);
+	SetConsoleTextAttribute(hOut, defaultAttributes);
+}
+
+void nmstermio_show_cursor(void)
+{
+	ensure_handles();
+	CONSOLE_CURSOR_INFO cursor = savedCursorInfo;
+	cursor.bVisible = TRUE;
+	SetConsoleCursorInfo(hOut, &cursor);
+	cursorHidden = 0;
+}
+
+void nmstermio_beep(void)
+{
+	Beep(750, 100);
+}
+
+int nmstermio_get_clearscr(void)
+{
+	return clearScr;
+}
+
+void nmstermio_set_clearscr(int s)
+{
+	if (s)
+		clearScr = 1;
+	else
+		clearScr = 0;
+}
+
+void nmstermio_set_foregroundcolor(char *c)
+{
+	if (c == NULL)
+	{
+		foregroundColor = 4;
+		return;
+	}
+
+	if (strcmp("white", c) == 0)
+		foregroundColor = 7;
+	else if (strcmp("yellow", c) == 0)
+		foregroundColor = 3;
+	else if (strcmp("black", c) == 0)
+		foregroundColor = 0;
+	else if (strcmp("magenta", c) == 0)
+		foregroundColor = 5;
+	else if (strcmp("blue", c) == 0)
+		foregroundColor = 4;
+	else if (strcmp("green", c) == 0)
+		foregroundColor = 2;
+	else if (strcmp("red", c) == 0)
+		foregroundColor = 1;
+	else if (strcmp("cyan", c) == 0)
+		foregroundColor = 6;
+	else
+		foregroundColor = 4;
+}
+
+#endif /* _WIN32 */

--- a/src/sneakers.c
+++ b/src/sneakers.c
@@ -8,7 +8,14 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+
+#ifdef _WIN32
+#define WIN32_LEAN_AND_MEAN
+#include <windows.h>
+#else
 #include <sys/ioctl.h>
+#endif
+
 #include "nmseffect.h"
 
 int main(void) {
@@ -30,14 +37,23 @@ int main(void) {
 	char *foot1Center    = "================================================================";
 	char *foot2Center    = "[ ] Select Option or ESC to Abort";
 
-	// Get terminal dimentions (needed for centering)
+	// Get terminal dimensions (needed for centering)
+#ifdef _WIN32
+	CONSOLE_SCREEN_BUFFER_INFO info;
+	if (!GetConsoleScreenBufferInfo(GetStdHandle(STD_OUTPUT_HANDLE), &info)) {
+		fprintf(stderr, "Input not from an interactive terminal\n");
+		return 1;
+	}
+	termCols = info.srWindow.Right - info.srWindow.Left + 1;
+#else
 	struct winsize w;
-    // if not an interactive tty, w is not populated, resulting in UB
+	// if not an interactive tty, w is not populated, resulting in UB
 	if (ioctl(0, TIOCGWINSZ, &w) == -1) {
-        perror("Input not from an interactive terminal");
-        return 1;
-    }
+		perror("Input not from an interactive terminal");
+		return 1;
+	}
 	termCols = w.ws_col;
+#endif
 
 	// Allocate space for our display string
 	if ((display = malloc(20 * termCols)) == NULL)


### PR DESCRIPTION
This pull request adds cross-platform support for Windows and introduces Zig as an alternative build system. The changes refactor platform-specific logic in the build process and source code to enable native compilation and execution on Windows. Additionally, improvements are made to input handling and effect rendering to ensure compatibility and stability across platforms.

**Build system improvements:**

* Added `build.zig` script to support building with Zig, enabling easier cross-platform builds, especially on Windows. [[1]](diffhunk://#diff-f87bb3596894756629bc39d595fb18d479dc4edf168d93a911cadcb060f10fccR1-R90) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R63-R79)
* Refactored `Makefile` to detect Windows environments and select appropriate source files, executable extensions, and libraries.

**Platform compatibility:**

* Updated source files (`src/nmseffect.c`, `src/sneakers.c`) to use Windows-specific APIs when building on Windows, including handling terminal dimensions and sleep functionality. [[1]](diffhunk://#diff-2d477f2e4c753ece7504d6c8279054b1780856c7ffc9623bf4789389483e0424L19-R26) [[2]](diffhunk://#diff-23c3557d06873167c7a05104d8845f1ec6c6e10efe204205c8181a6918e183a9R11-R18) [[3]](diffhunk://#diff-23c3557d06873167c7a05104d8845f1ec6c6e10efe204205c8181a6918e183a9L33-R56) [[4]](diffhunk://#diff-2d477f2e4c753ece7504d6c8279054b1780856c7ffc9623bf4789389483e0424R358-R385)
* Added a wrapper for `wcwidth` to provide a reliable character width calculation on Windows. [[1]](diffhunk://#diff-2d477f2e4c753ece7504d6c8279054b1780856c7ffc9623bf4789389483e0424R55) [[2]](diffhunk://#diff-2d477f2e4c753ece7504d6c8279054b1780856c7ffc9623bf4789389483e0424L148-R152) [[3]](diffhunk://#diff-2d477f2e4c753ece7504d6c8279054b1780856c7ffc9623bf4789389483e0424R358-R385)

**Input handling:**

* Refactored `input_get` in `src/input.c` to simplify input reading and improve error handling, removing platform-dependent code and ensuring robust memory management. [[1]](diffhunk://#diff-4fdb31943fd145fd3cb67fd6bd0f7ce3e30f0887de4c3ab05e06fb5102d823c3R8-R78) [[2]](diffhunk://#diff-4fdb31943fd145fd3cb67fd6bd0f7ce3e30f0887de4c3ab05e06fb5102d823c3R131)